### PR TITLE
don't throw exception in reverseTransform when id is empty but return null

### DIFF
--- a/DataTransformer/EntityToIdentifierTransformer.php
+++ b/DataTransformer/EntityToIdentifierTransformer.php
@@ -53,7 +53,7 @@ class EntityToIdentifierTransformer implements DataTransformerInterface
     public function reverseTransform($id)
     {
         if (!$id) {
-            throw new TransformationFailedException("No id was submitted");
+            return null;
         }
 
         $entity = $this->om->getRepository($this->entityRepository)->find($id);


### PR DESCRIPTION
As stated in the docblock in `DataTransformerInterface`:

> By convention, reverseTransform() should return NULL if an empty string
> is passed.

I spend too much time on a problem related to this. Sometime the entity is just empty (it's gonna be created on submit for example). I know now that when a transformer throws an exception, all you get in the form is an error message "this value is invalid" and you have no clue about what is wrong and where.
