### PR TITLE
Symfony 3 compatibility update

### DIFF
--- a/Type/HiddenEntityType.php
+++ b/Type/HiddenEntityType.php
@@ -75,14 +75,6 @@ class HiddenEntityType extends AbstractType
      */
     public function getParent()
     {
-        return 'hidden';
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'hidden_entity';
+        return '\Symfony\Component\Form\Extension\Core\Type\HiddenType';
     }
 }


### PR DESCRIPTION
- Remove getName() (replaced w/ getBlockPrefix but it's auto generated)
- Update getParent() to return the fully qualified class name