### PR TITLE
Updating HiddenEntityType to be Symfony 3.0 compliant.

### DIFF
--- a/Type/HiddenEntityType.php
+++ b/Type/HiddenEntityType.php
@@ -70,18 +70,37 @@ class HiddenEntityType extends AbstractType
     }
 
     /**
-     * Set the parent form type to hidden
+     * Set the parent form type to Symfony core HiddenType
+     *
+     * TODO: when drop Symfony 2.x support, add use statement above
+     *       for HiddenType core class and return HiddenType::class
+     *       here instead of path string
+     *
      * @return string
      */
     public function getParent()
     {
-        return 'hidden';
+        return 'Symfony\Component\Form\Extension\Core\Type\HiddenType';
     }
 
     /**
+     * Symfony 2.x version of getBlockPrefix()
+     *
+     * TODO: when drop Symfony 2.x support, remove this method
+     *
      * @return string
      */
     public function getName()
+    {
+        return 'hidden_entity';
+    }
+
+    /**
+     * Prefix form input field id attributes with 'hidden_entity'
+     *
+     * @return string
+     */
+    public function getBlockPrefix()
     {
         return 'hidden_entity';
     }


### PR DESCRIPTION
Currently the HiddenEntityType throws two deprecation warnings related to the getName() method and the use of 'hidden' string in getParent(), instead of the fully qualified class name of HiddenType. These changes make HiddenEntityType Symfony 3.0 compliant, without breaking backwards compatibility with Symfony 2.x.  I also added TODOs to make adjustments if/when you decide to stop supporting Symfony 2.x.

These fixes will make the 'hidden' string deprecation warning go away.  The getName() warning will persist, but after the user upgrades to Symfony 3.0 it will go away, and nothing will break.